### PR TITLE
add broadcasting function

### DIFF
--- a/boswatch/network/broadcast.py
+++ b/boswatch/network/broadcast.py
@@ -73,7 +73,6 @@ class BroadcastClient:
         logging.warning("cannot fetch connection info after %d tries", sendPackages)
         return False
 
-
     @property
     def serverIP(self):
         """!Property to get the server IP after successful broadcast"""
@@ -88,9 +87,10 @@ class BroadcastClient:
 class BroadcastServer:
     """!BroadcastServer class"""
 
-    def __init__(self, servePort=8080,listenPort=5000):
+    def __init__(self, servePort=8080, listenPort=5000):
         """!Create an BroadcastServer instance
 
+        @param servePort: port to serve as connection info (8080)
         @param listenPort: port to listen for broadcast packets (5000)"""
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/boswatch/network/broadcast.py
+++ b/boswatch/network/broadcast.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""!
+    ____  ____  ______       __      __       __       _____
+   / __ )/ __ \/ ___/ |     / /___ _/ /______/ /_     |__  /
+  / __  / / / /\__ \| | /| / / __ `/ __/ ___/ __ \     /_ <
+ / /_/ / /_/ /___/ /| |/ |/ / /_/ / /_/ /__/ / / /   ___/ /
+/_____/\____//____/ |__/|__/\__,_/\__/\___/_/ /_/   /____/
+                German BOS Information Script
+                     by Bastian Schroll
+
+@file:        broadcast.py
+@date:        21.09.2018
+@author:      Bastian Schroll
+@description: UDP broadcast server and client class
+"""
+import logging
+import socket
+
+logging.debug("- %s loaded", __name__)
+
+
+class BroadcastClient:
+
+    def __init__(self, port=5000):
+        self._broadcastPort = port
+
+        self._serverIP = ""
+        self._serverPort = 0
+
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        self._socket.settimeout(3)
+
+    def sendBroadcast(self):
+        while True:
+            try:
+
+                logging.debug("send magic <BW3-Request>")
+                self._socket.sendto("<BW3-Request>".encode(), ('255.255.255.255', self._broadcastPort))
+                payload, address = self._socket.recvfrom(1024)
+                payload = str(payload, "UTF-8")
+
+                if payload.startswith("<BW3-Result>"):
+                    logging.debug("received magic <BW3-Result>")
+                    self._serverIP = address[0]
+                    self._serverPort = int(payload.split(";")[1])
+                    logging.info("got connection info: %s:%d", self._serverIP, self._serverPort)
+                    return True
+            except socket.timeout:
+                logging.warning("retry sending magic")
+                continue
+            except:
+                logging.exception("error on getting connection info")
+                return False
+
+    @property
+    def serverIP(self):
+        return self._serverIP
+
+    @property
+    def serverPort(self):
+        return self._serverPort
+
+
+class BroadcastServer:
+    """!General class comment"""
+
+    def __init__(self, port=5000):
+        """!init comment"""
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._socket.bind(('', port))
+
+    def listen(self):
+        try:
+            logging.debug("start listening for magic")
+            while True:
+                payload, address = self._socket.recvfrom(1024)
+                payload = str(payload, "UTF-8")
+                if payload == "<BW3-Request>":
+                    logging.debug("received magic <BW3-Request> from: %s", address[0])
+                    logging.debug("send connection info in magic <BW3-Result>")
+                    self._socket.sendto("<BW3-Result>;8080".encode(), address)  # todo give the TCPServer port
+                    return True
+        except:
+            logging.exception("error while listening for clients")

--- a/boswatch/network/broadcast.py
+++ b/boswatch/network/broadcast.py
@@ -55,7 +55,7 @@ class BroadcastClient:
         sendPackages = 1
         while sendPackages <= retry or retry == 0:
             try:
-                logging.debug("send magic <BW3-Request> as broadcast - #%d", sendPackages)
+                logging.debug("send magic <BW3-Request> as broadcast - Try: %d", sendPackages)
                 self._socket.sendto("<BW3-Request>".encode(), ('255.255.255.255', self._broadcastPort))
                 payload, address = self._socket.recvfrom(1024)
                 payload = str(payload, "UTF-8")
@@ -107,29 +107,37 @@ class BroadcastServer:
 
         @return True or False"""
         try:
-            logging.debug("start udp broadcast server")
-            self._serverThread = threading.Thread(target=self._listen)
-            self._serverThread.name = "BroadServ"
-            self._serverThread.daemon = True
-            self._serverIsRunning = True
-            self._serverThread.start()
-            return True
+            if not self._serverIsRunning:
+                logging.debug("start udp broadcast server")
+                self._serverThread = threading.Thread(target=self._listen)
+                self._serverThread.name = "BroadServ"
+                self._serverThread.daemon = True
+                self._serverIsRunning = True
+                self._serverThread.start()
+                return True
+            else:
+                logging.warning("udp broadcast server always started")
+                return True
         except:
             logging.exception("cannot start udp broadcast server thread")
             return False
 
-    def stopp(self):
+    def stop(self):
         """!Stop the broadcast server
 
         Due to the timeout of the socket,
-        stopping the thread can be delayed by two seconds
+        stopping the thread can be delayed by two seconds.
+        But function returns immediately.
 
         @return True or False"""
         try:
-            logging.debug("stop udp broadcast server")
-            self._serverIsRunning = False
-            # self._serverThread.join()
-            return True
+            if not self._serverIsRunning:
+                logging.debug("stop udp broadcast server")
+                self._serverIsRunning = False
+                return True
+            else:
+                logging.warning("udp broadcast server always stopped")
+                return True
         except:
             logging.exception("cannot stop udp broadcast server thread")
             return False
@@ -156,3 +164,8 @@ class BroadcastServer:
             except:
                 logging.exception("error while listening for clients")
         logging.debug("udp broadcast server stopped")
+
+    @property
+    def isRunning(self):
+        """!Property of broadcast server running state"""
+        return self._serverIsRunning

--- a/bw_server.py
+++ b/bw_server.py
@@ -63,9 +63,13 @@ except Exception as e:  # pragma: no cover
 server = BroadcastServer()
 client = BroadcastClient()
 server.start()
+print(server.isRunning)
 client.getConnInfo()
 print(client.serverIP, client.serverPort)
 server.stop()
+print(server.isRunning)
+time.sleep(2)
+print(server.isRunning)
 
 try:
     header.logoToLog()

--- a/bw_server.py
+++ b/bw_server.py
@@ -51,11 +51,21 @@ try:
     from boswatch.descriptor.descriptor import Descriptor
     from boswatch.filter.doubeFilter import DoubleFilter
     from boswatch.utils import header
+    from boswatch.network.broadcast import BroadcastClient
+    from boswatch.network.broadcast import BroadcastServer
 except Exception as e:  # pragma: no cover
     logging.exception("cannot import modules")
     print("cannot import modules")
     print(e)
     exit(1)
+
+#  Test for the broadcast connection info function
+server = BroadcastServer()
+client = BroadcastClient()
+server.start()
+client.getConnInfo()
+print(client.serverIP, client.serverPort)
+server.stop()
 
 try:
     header.logoToLog()

--- a/test/test_broadcast.py
+++ b/test/test_broadcast.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""!
+    ____  ____  ______       __      __       __       _____
+   / __ )/ __ \/ ___/ |     / /___ _/ /______/ /_     |__  /
+  / __  / / / /\__ \| | /| / / __ `/ __/ ___/ __ \     /_ <
+ / /_/ / /_/ /___/ /| |/ |/ / /_/ / /_/ /__/ / / /   ___/ /
+/_____/\____//____/ |__/|__/\__,_/\__/\___/_/ /_/   /____/
+                German BOS Information Script
+                     by Bastian Schroll
+
+@file:        test_broadcast.py
+@date:        25.09.2018
+@author:      Bastian Schroll
+@description: Unittests for BOSWatch. File must be _run as "pytest" unittest
+"""
+import logging
+import time
+import pytest
+
+from boswatch.network.broadcast import BroadcastServer
+from boswatch.network.broadcast import BroadcastClient
+
+
+class Test_Timer:
+    """!Unittest for the timer class"""
+
+    def setup_method(self, method):
+        logging.debug("[TEST] %s.%s", type(self).__name__, method.__name__)
+
+    @pytest.fixture(scope="function")
+    def useBroadcastServer(self):
+        """!Server a BroadcastServer instance"""
+        self.broadcastServer = BroadcastServer()
+        yield 1  # server the server instance
+        if self.broadcastServer.isRunning:
+            assert self.broadcastServer.stop()
+        while self.broadcastServer.isRunning:
+            pass
+
+    @pytest.fixture(scope="function")
+    def useBroadcastClient(self):
+        """!Server a BroadcastClient instance"""
+        self.broadcastClient = BroadcastClient()
+        yield 1  # server the server instance
+
+    # tests start here
+
+    def test_serverStartStop(self, useBroadcastServer):
+        assert self.broadcastServer.start()
+        assert self.broadcastServer.isRunning
+        assert self.broadcastServer.stop()
+
+    def test_serverDoubleStart(self, useBroadcastServer):
+        assert self.broadcastServer.start()
+        assert self.broadcastServer.start()
+        assert self.broadcastServer.stop()
+
+    def test_serverStopNotStarted(self, useBroadcastServer):
+        assert self.broadcastServer.stop()
+
+    def test_clientWithoutServer(self, useBroadcastClient):
+        assert not self.broadcastClient.getConnInfo(1)
+
+    def test_serverClientFetchConnInfo(self, useBroadcastServer, useBroadcastClient):
+        assert self.broadcastServer.start()
+        assert self.broadcastClient.getConnInfo()
+        assert self.broadcastServer.stop()
+        assert self.broadcastClient.serverIP
+        assert self.broadcastClient.serverPort


### PR DESCRIPTION
Implementiert einen UDP Boradcast server und clienten
- Server startet einen UDP Server und lauscht auf magic-packets
- Client der die Server IP und Port möchte sendet per UDP Broadcast ein magic-packet
- Server empfängt dieses und schickt dem Clienten direkt (nicht per broadcast) die IP und den Port
- Der Client kann nun normal per TCP auf den Server connecten

- [x] Documentieren
- [x] Unittest schreiben