### PR TITLE
Fixed Typo

### DIFF
--- a/module/template_module.py
+++ b/module/template_module.py
@@ -25,7 +25,7 @@ from module.moduleBase import ModuleBase
 logging.debug("- %s loaded", __name__)
 
 
-class BoswatchModul(ModuleBase):
+class BoswatchModule(ModuleBase):
     """!Description of the Module"""
     def __init__(self, config):
         """!Do not change anything here!"""


### PR DESCRIPTION
Wenn man das Template als Vorlage nimmt, geht es mit dem richtigen Klassen-Namen besser