### PR TITLE
Fix offline timestamp problem

### DIFF
--- a/boswatch/inputSource/inputBase.py
+++ b/boswatch/inputSource/inputBase.py
@@ -20,6 +20,7 @@ import threading
 from abc import ABC, abstractmethod
 from boswatch.utils import paths
 from boswatch.processManager import ProcessManager
+from boswatch.decoder.decoder import Decoder
 
 logging.debug("- %s loaded", __name__)
 
@@ -61,10 +62,11 @@ class InputBase(ABC):
             logging.debug("input thread stopped")
 
     def addToQueue(self, data):
-        """!Adds alarm data to the queue for further processing during boswatch client"""
-        self._inputQueue.put_nowait((data, time.time()))
-        logging.debug("Add received data to queue")
-        print(data)
+        """!Decode and add alarm data to the queue for further processing during boswatch client"""
+        bwPacket = Decoder.decode(data)
+        if bwPacket is not None:
+            self._inputQueue.put_nowait((bwPacket, time.time()))
+            logging.debug("Added received data to queue")
 
     def getDecoderInstance(self, decoderConfig, StdIn):
         mmProc = ProcessManager(str(decoderConfig.get("path", default="multimon-ng")), textMode=True)

--- a/bw_client.py
+++ b/bw_client.py
@@ -51,6 +51,7 @@ from boswatch.utils import misc
 from boswatch.inputSource.sdrInput import SdrInput
 from boswatch.inputSource.lineInInput import LineInInput
 from boswatch.inputSource.pulseaudioInput import PulseAudioInput
+from boswatch.decoder.decoder import Decoder  # for test mode
 
 header.logoToLog()
 header.infoToLog()
@@ -105,7 +106,8 @@ try:
         for testData in testFile:
             if (len(testData.rstrip(' \t\n\r')) > 1) and ("#" not in testData[0]):
                 logging.info("Testdata: %s", testData.rstrip(' \t\n\r'))
-                inputQueue.put_nowait((testData.rstrip(' \t\n\r'), time.time()))
+                bwPacket = Decoder.decode(testData.rstrip(' \t\n\r'))
+                inputQueue.put_nowait((bwPacket, time.time()))
         logging.debug("finished reading testdata")
 
     bwClient = TCPClient()

--- a/bw_client.py
+++ b/bw_client.py
@@ -46,7 +46,6 @@ logging.debug("Import BOSWatch modules")
 from boswatch.configYaml import ConfigYAML
 from boswatch.network.client import TCPClient
 from boswatch.network.broadcast import BroadcastClient
-from boswatch.decoder.decoder import Decoder
 from boswatch.utils import header
 from boswatch.utils import misc
 from boswatch.inputSource.sdrInput import SdrInput
@@ -123,12 +122,8 @@ try:
             data = inputQueue.get()
             logging.info("get data from queue (waited %0.3f sec.)", time.time() - data[1])
             logging.debug("%s packet(s) still waiting in queue", inputQueue.qsize())
-
-            bwPacket = Decoder.decode(data[0])
+            bwPacket = data[0]
             inputQueue.task_done()
-
-            if bwPacket is None:
-                continue
 
             bwPacket.printInfo()
             misc.addClientDataToPacket(bwPacket, bwConfig)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # for pip to install all needed
-# called with 'pip -r requirements.txt'
-
+# called with 'pip install -r requirements.txt'
 pyyaml
 
 # for documentation generating


### PR DESCRIPTION
Problem war:
- Timestamps wurden beim erstellen (decodieren) des bwPackets erzeugt.
- Dies geschah nur/erst, wenn eine Verbindung zum Server bestand
- Im Falle eines Verlusts der Verbindung zum Server wurden die Rohdaten in einer Queue vorgehalten und erst beim Reconnect decodiert (timestamp also falsch)

Jetzt werden die Pakete direkt in der InputBase dekodiert und damit der Timestamp direkt nach dem Empfangen erstellt - nicht erst beim versenden an den Server.

**Noch ungetestet**
fix #56 