### PR TITLE
Drop python 3.5 testing

### DIFF
--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{matrix.os}}
 
     steps:


### PR DESCRIPTION
Official Python 3.5 End-of-life was at 13 Sep 2020.
This PR will drop the unittesting support for this outdated version

see: https://endoflife.date/python