### PR TITLE
Fix timer error

### DIFF
--- a/boswatch/timer.py
+++ b/boswatch/timer.py
@@ -64,7 +64,8 @@ class RepeatedTimer:
         if self._thread is not None:
             logging.debug("stop repeatedTimer: %s", self._thread.name)
             self._event.set()
-            self._thread.join()
+            if self._thread is not None:
+                self._thread.join()
             return True
         logging.warning("repeatedTimer always stopped")
         return True

--- a/boswatch/timer.py
+++ b/boswatch/timer.py
@@ -61,9 +61,9 @@ class RepeatedTimer:
         """!Stop the timer worker thread
 
         @return True or False"""
-        self._event.set()
         if self._thread is not None:
             logging.debug("stop repeatedTimer: %s", self._thread.name)
+            self._event.set()
             self._thread.join()
             return True
         logging.warning("repeatedTimer always stopped")


### PR DESCRIPTION
There was a error with the timer component.
Sometimes the thread was closed very fast (will set to None) before we call the join.
```
________________________________ test_timerRun _________________________________

useTimerFast = <boswatch.timer.RepeatedTimer object at 0x7f832e2734c0>

    def test_timerRun(useTimerFast):
        """!Run a timer and check overdue and lostEvents"""
        assert useTimerFast.start()
        time.sleep(0.2)
>       assert useTimerFast.stop()

test/boswatch/test_timer.py:89: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <boswatch.timer.RepeatedTimer object at 0x7f832e2734c0>

    def stop(self):
        """!Stop the timer worker thread
    
        @return True or False"""
        self._event.set()
        if self._thread is not None:
            logging.debug("stop repeatedTimer: %s", self._thread.name)
>           self._thread.join()
E           AttributeError: 'NoneType' object has no attribute 'join'

boswatch/timer.py:67: AttributeError
```