### PR TITLE
Fix issue if additionalWildcard is not empty (eg. descriptor)

### DIFF
--- a/boswatch/wildcard.py
+++ b/boswatch/wildcard.py
@@ -97,8 +97,9 @@ def replaceWildcards(message, bwPacket):
         if field is not None:
             message = message.replace(wildcard, field)
 
-    for wildcard, field in _additionalWildcards.items():
+    for wildcard, fieldName in _additionalWildcards.items():
+        field = bwPacket.get(fieldName)
         if field is not None:
-            message = message.replace(wildcard, bwPacket.get(field))
+            message = message.replace(wildcard, field)
 
     return message


### PR DESCRIPTION
There was a problem with the wildcard replacement, when additional wildcard were not set (eg. using the descriptor to only set a wildcard for 1 ric)

Liked with Issue #75 

# Example:

![photo5362021491304149490](https://user-images.githubusercontent.com/27723865/111037356-f4c1de80-8423-11eb-8922-5e124afcc3ca.jpg)
