### PR TITLE
Default value not working (fir_size)

### DIFF
--- a/boswatch/inputSource/sdrInput.py
+++ b/boswatch/inputSource/sdrInput.py
@@ -36,7 +36,7 @@ class SdrInput(InputBase):
             sdrProc.addArgument("-p " + str(sdrConfig.get("error", default="0")))      # frequency error in ppm
             sdrProc.addArgument("-l " + str(sdrConfig.get("squelch", default="1")))    # squelch
             sdrProc.addArgument("-g " + str(sdrConfig.get("gain", default="100")))     # gain
-            if sdrConfig.get("fir_size", default=None):
+            if (sdrConfig.get("fir_size", default=None) is not None):
                 sdrProc.addArgument("-F " + str(sdrConfig.get("fir_size")))            # fir_size
             sdrProc.addArgument("-M fm")                                               # set mode to fm
             sdrProc.addArgument("-E DC")                                               # set DC filter

--- a/docu/docs/config.md
+++ b/docu/docs/config.md
@@ -49,7 +49,7 @@ Mit `PulseAudio` wird ein PulseAudio-Sink an Multimon-NG weitergereicht, z.B. in
 |error|Frequenz Abweichung in ppm|0|
 |squelch|Einstellung der Rauschsperre|1|
 |gain|Verstärkung des Eingangssignals|100|
-|fir_size| niedrig leckagearmen Filter, default 0 = off||
+|fir_size| niedrig leckagearmen Filter|None|
 |rtlPath|Pfad zur rtl_fm Binary|rtl_fm|
 
 **Beispiel:**


### PR DESCRIPTION
Der Standard in der Einstellung ist ohne Funktion.

Wenn die fir_size 0 ist, wird der Wert gar nicht ausgegeben. Der Wert soll ausgegeben, wenn er gesetzt ist.