### PR TITLE
Issue #101: Restart multimon on broken input

### DIFF
--- a/boswatch/inputSource/lineInInput.py
+++ b/boswatch/inputSource/lineInInput.py
@@ -48,6 +48,11 @@ class LineInInput(InputBase):
                 if not lineInProc.isRunning:
                     logging.warning("asla was down - try to restart")
                     lineInProc.start()
+
+                    if lineInProc.isRunning:
+                        logging.info("rtl_fm is back up - restarting multimon...")
+                        mmProc.setStdin(lineInProc.stdout)
+                        mmProc.start()
                 elif not mmProc.isRunning:
                     logging.warning("multimon was down - try to restart")
                     mmProc.start()

--- a/boswatch/inputSource/pulseaudioInput.py
+++ b/boswatch/inputSource/pulseaudioInput.py
@@ -47,6 +47,11 @@ class PulseAudioInput(InputBase):
                 if not PulseAudioProc.isRunning:
                     logging.warning("PulseAudio was down - try to restart")
                     PulseAudioProc.start()
+                                        
+                    if PulseAudioProc.isRunning:
+                        logging.info("rtl_fm is back up - restarting multimon...")
+                        mmProc.setStdin(PulseAudioProc.stdout)
+                        mmProc.start()
                 elif not mmProc.isRunning:
                     logging.warning("multimon was down - try to restart")
                     mmProc.start()

--- a/boswatch/inputSource/pulseaudioInput.py
+++ b/boswatch/inputSource/pulseaudioInput.py
@@ -47,7 +47,7 @@ class PulseAudioInput(InputBase):
                 if not PulseAudioProc.isRunning:
                     logging.warning("PulseAudio was down - try to restart")
                     PulseAudioProc.start()
-                                        
+
                     if PulseAudioProc.isRunning:
                         logging.info("rtl_fm is back up - restarting multimon...")
                         mmProc.setStdin(PulseAudioProc.stdout)


### PR DESCRIPTION
Für alle InputSources (außer rtl_fm, das ist schon gefixed) startet Multimon bei einem Ausfall des Input-Prozesses nicht neu, was zu einer Endlos-Schleife führen kann. - siehe https://bwcc.boswatch.de/boswatch/pl/riifysszrpfcpet37zgsgoxxtr
