### PR TITLE
Pytest update

### DIFF
--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -1,7 +1,6 @@
 name: pytest
 
 on:
-  #workflow_dispatch:       # Hier manuelles Starten erlauben, automatisch nach jedem Commit
   push:
   pull_request:
 

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -33,7 +33,7 @@ jobs:
         pytest -c 'test/pytest.ini'
 
     - name: Save artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test.log
         path: log/test.log

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -35,5 +35,5 @@ jobs:
     - name: Save artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: test.log
+        name: test-${{ matrix.python-version }}.log
         path: log/test.log

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -1,7 +1,7 @@
 name: pytest
 
 on:
-  workflow_dispatch:       # Hier manuelles Starten erlauben
+  #workflow_dispatch:       # Hier manuelles Starten erlauben, automatisch nach jedem Commit
   push:
   pull_request:
 

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ${{matrix.os}}
 
     steps:

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -8,11 +8,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{matrix.python-version}} at ${{matrix.os}}
       uses: actions/setup-python@v3
@@ -23,14 +23,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        mkdir log/
+        mkdir -p log/
 
     - name: Test with pytest
       run: |
         pytest -c 'test/pytest.ini'
 
     - name: Save artifacts
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v3
       with:
         name: test.log
         path: log/test.log

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     runs-on: ${{matrix.os}}
 
     steps:

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -1,6 +1,9 @@
 name: pytest
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:       # Hier manuelles Starten erlauben
+  push:
+  pull_request:
 
 jobs:
   build:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ mkdocs
 # for develope only
 pytest
 pytest-cov
-flake8==4.0.1
+flake8==6.1.0
 pytest-flake8
 pytest-flakes
 pytest-randomly


### PR DESCRIPTION
Pytest scheitert am Test mit der Python Version 3.7. Da inzwischen die Python-Version 3.13 veröffentlicht worden ist mit in Kürze 3.14, würde ich ein Heben zur Version 3.8 vorschlagen.
Raspbian OS auf Basis Bookworm kommt mit 3.11.2 preinstalled
(z.B. mein Setting:
Raspberry Pi 3B+
Raspberry Pi OS Lite
Release date: May 13th 2025
System: 64-bit
Kernel version: 6.12
Debian version: 12 (bookworm))
hat python3.11.2.

Zusammenfassend die Änderungen:
in Pytest:
* auskommentiert die Option "workflow_dispatch", die ein Testen nach jedem Commit ermöglicht für Developer.
* Python-Versionen 3.9-3.13 in der Testroutine
* actions/checkout@v1 auf actions/checkout@v3 gehoben
* mkdir -p log/ --> Falls kein Log besteht, wird eines angelegt
* actions/upload-artifact@master auf actions/upload-artifact@v4 gehoben
* test.log zu test-${{ matrix.python-version }}.log verändert, da Pytest meckert, weil nur ein Log (zumindest bei mir)

in requirements.txt
* flake8==4.0.1 auf flake8==6.1.0 gehoben (möglich durch Entlassen der python v3.8)

Jetzt bin ich natürlich eher schlecht im Python und deshalb eine bitte an euch Python-Experten... Macht das Sinn oder lacht ihr mich aus, weil alles verkehrt und ich übersehe was fundamentales?