### PR TITLE
Änderung der Workflow-Datei "build_docs.yml" für das ablösen der ph_pages Branch zum Aufbau der Website

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -3,8 +3,8 @@ name: build_docs
 on:
   push:
     branches:
-     #- master
-     - develop
+      #- master
+      - develop
 
 permissions:
   contents: read

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -3,35 +3,50 @@ name: build_docs
 on:
   push:
     branches:
-#     - master
-      - develop
+     #- master
+     - develop
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-
   build_docs:
     name: Build documentation
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10']
-
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: x64
-
+      uses: actions/checkout@v4
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y doxygen
+        pip install mkdocs
     - name: Build doxygen
-      uses: mattnotmitt/doxygen-action@v1
+      run: doxygen docu/doxygen.ini
+    - name: Build MkDocs site
+      working-directory: docu
+      run: mkdocs build --site-dir site
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
       with:
-        working-directory: './'
-        doxyfile-path: 'docu/doxygen.ini'
+        path: ./docu/site
 
-    - name: Install mkdocs
-      run: pip install mkdocs
-    - name: Build Docs and Deploy to Github Pages
-      run: python -m mkdocs gh-deploy -f docu/mkdocs.yml --force
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build_docs
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
NEU:
* permissions-Sektor
* concurrency-Sektor
* setup Pages in jobs - build_docs eingefügt
* Build mkdocs in jobs - build_docs eingefügt
* Upload artifact in jobs - build_docs eingefügt
* Deployment job-Sektor

Entfernt:
* Build_docs strategy
* Setup Python (in Dokumentation nicht gebraucht? <-- bitte kritisch prüfen)
* Python in jobs - build_docs

Geändert:
* Checkout von v2 auf v4
* Install Dependencies zusammengefasst
* bei Doxygen mattnotmitt/doxygen-action@v1 entfernt, Code verschlankt

Sollte #120 teilweise(!) lösen

ACHTUNG:
@Schrolli91 oder wer noch Zugriff auf die Settings des Repro hat:
Bitte mit Merge des PR dann folgendes kontrollieren, um Fehlerquellen auszuschließen:

unter Settings -> Pages -> Build and Deployment -> Source: "GitHub Actions" auswählen
![Check1](https://github.com/user-attachments/assets/729a9732-3416-4782-a438-973844d405ee)

unter Settings -> Environments -> github-pages auswählen (auf den text "github-pages" klicken)
![Check2-1](https://github.com/user-attachments/assets/6368f05e-4270-4a7c-ba88-1c39b75d4a4b)

in dem Menüpunkt unten checken, dass bei den "Deployment branches and tags" auch "develop" drin steht und hinten "Currently applies to 1 branch"
Falls nicht, dann unten "+ Add Deployment branch or tag rule", dort dann 
- Ref type: branch
- Name pattern: develop
(Bitte auf typos achten!)

![Check2-2](https://github.com/user-attachments/assets/63231a74-7f1d-4684-91c2-56379ac6c3c4)

Dann sollte unmittelbar in der Liste develop auftauchen und auch hinten "Currently applies to 1 branch".