### PR TITLE
Bugfix der Bild-Links

### DIFF
--- a/docu/docs/index.md
+++ b/docu/docs/index.md
@@ -1,9 +1,7 @@
 # <center>BOSWatch 3</center>
 ---
 
-<center>
 ![BOSWatch](img/bw3.png "BOSWatch 3 Logo")
-</center>
 
 **Es wird darauf hingewiesen, dass für die Teilnahme am BOS-Funk nur nach den Technischen Richtlinien der BOS zugelassene Funkanlagen verwendet werden dürfen.**
 **Der BOS-Funk ist ein nichtöffentlicher mobiler Landfunk. Privatpersonen gehören nicht zum Kreis der berechtigten Funkteilnehmer.** _(Quelle: TR-BOS)_
@@ -14,9 +12,7 @@
 
 ---
 
-<center>
 Falls du uns unterstützen möchtest würden wir uns über eine Spende freuen.  
 Server, Hosting, Domain sowie Kaffee kosten leider Geld ;-)  
 
-[![](https://www.paypalobjects.com/de_DE/DE/i/btn/btn_donate_LG.gif)](https://www.paypal.me/BSchroll)
-</center>
+[![DonateMe](https://www.paypalobjects.com/de_DE/DE/i/btn/btn_donate_LG.gif)](https://www.paypal.me/BSchroll)

--- a/docu/docs/index.md
+++ b/docu/docs/index.md
@@ -1,7 +1,8 @@
 # <center>BOSWatch 3</center>
 ---
 
-![BOSWatch](img/bw3.png "BOSWatch 3 Logo")
+![BOSWatch](img/bw3.png){ .center }
+
 
 **Es wird darauf hingewiesen, dass für die Teilnahme am BOS-Funk nur nach den Technischen Richtlinien der BOS zugelassene Funkanlagen verwendet werden dürfen.**
 **Der BOS-Funk ist ein nichtöffentlicher mobiler Landfunk. Privatpersonen gehören nicht zum Kreis der berechtigten Funkteilnehmer.** _(Quelle: TR-BOS)_
@@ -15,4 +16,4 @@
 Falls du uns unterstützen möchtest würden wir uns über eine Spende freuen.  
 Server, Hosting, Domain sowie Kaffee kosten leider Geld ;-)  
 
-[![DonateMe](https://www.paypalobjects.com/de_DE/DE/i/btn/btn_donate_LG.gif)](https://www.paypal.me/BSchroll)
+[![DonateMe](https://www.paypalobjects.com/de_DE/DE/i/btn/btn_donate_LG.gif)](https://www.paypal.me/BSchroll){ .center }

--- a/docu/docs/information/broadcast.md
+++ b/docu/docs/information/broadcast.md
@@ -10,7 +10,7 @@ Durch den Broadcast Service haben Clients die Möglichkeit, automatisch den Serv
 Der Broadcast Service besteht aus 2 Teilen - einem Server und einem Clienten.  
 Nachfolgend soll der Ablauf einer Verbindung des Clienten zum Server mittels des Broadcast Services erklärt werden.
 
-<center>![](../img/broadcast.png)</center>
+![Broadcast](../img/broadcast.png)
 
 ---
 ## Ablauf

--- a/docu/docs/information/broadcast.md
+++ b/docu/docs/information/broadcast.md
@@ -10,7 +10,7 @@ Durch den Broadcast Service haben Clients die Möglichkeit, automatisch den Serv
 Der Broadcast Service besteht aus 2 Teilen - einem Server und einem Clienten.  
 Nachfolgend soll der Ablauf einer Verbindung des Clienten zum Server mittels des Broadcast Services erklärt werden.
 
-![Broadcast](../img/broadcast.png)
+![Broadcast](../img/broadcast.png){ .center }
 
 ---
 ## Ablauf

--- a/docu/docs/information/router.md
+++ b/docu/docs/information/router.md
@@ -8,7 +8,7 @@ BOSWatch 3 hat einen Routing Mechanismus integriert. Mit diesem ist es auf einfa
 
 Nachfolgender Ablauf soll am Beispiel eines Alarms mit einem Pocsag Paket erklärt werden.
 
-<center>![](../img/router.png)</center>
+![Routing-Mechanismus](../img/router.png)
 
 - BOSWatch startet alle Router, welche in der config als `alarmRouter` konfiguriert worden sind (in diesem Fall nur `Router1`)
 - Der Router `Router1` beginnt seine Ausführung und arbeitet die einzelnen Routenpunkte sequentiell ab

--- a/docu/docs/information/router.md
+++ b/docu/docs/information/router.md
@@ -8,7 +8,7 @@ BOSWatch 3 hat einen Routing Mechanismus integriert. Mit diesem ist es auf einfa
 
 Nachfolgender Ablauf soll am Beispiel eines Alarms mit einem Pocsag Paket erklärt werden.
 
-![Routing-Mechanismus](../img/router.png)
+![Routing-Mechanismus](../img/router.png){ .center }
 
 - BOSWatch startet alle Router, welche in der config als `alarmRouter` konfiguriert worden sind (in diesem Fall nur `Router1`)
 - Der Router `Router1` beginnt seine Ausführung und arbeitet die einzelnen Routenpunkte sequentiell ab

--- a/docu/docs/information/serverclient.md
+++ b/docu/docs/information/serverclient.md
@@ -17,7 +17,7 @@ nachträglich an den Server übermittelt werden.
 
 Dabei überwacht der Client selbstständig die benötigten Programme zum Empfang der Daten und startet diese bei einem Fehler ggf. neu.
 
-![Client-Prinzip](../img/client.png)
+![Client-Prinzip](../img/client.png){ .center }
 
 ---
 ## BOSWatch Server
@@ -30,4 +30,4 @@ dauernden Plugin Ausführung alle Pakete korrekt empfangen werden können und es
 Die Verarbeitung der Pakete geschieht anschließend in sogenannten Routern, welche aufgrund ihres Umfangs jedoch in einem eigenen Kapitel
 erklärt werden. Diese steuern die Verteilung der Daten an die einzelnen Plugins.
 
-![Server-Prinzip](../img/server.png)
+![Server-Prinzip](../img/server.png){ .center }

--- a/docu/docs/information/serverclient.md
+++ b/docu/docs/information/serverclient.md
@@ -17,7 +17,7 @@ nachträglich an den Server übermittelt werden.
 
 Dabei überwacht der Client selbstständig die benötigten Programme zum Empfang der Daten und startet diese bei einem Fehler ggf. neu.
 
-<center>![](../img/client.png)</center>
+![Client-Prinzip](../img/client.png)
 
 ---
 ## BOSWatch Server
@@ -30,4 +30,4 @@ dauernden Plugin Ausführung alle Pakete korrekt empfangen werden können und es
 Die Verarbeitung der Pakete geschieht anschließend in sogenannten Routern, welche aufgrund ihres Umfangs jedoch in einem eigenen Kapitel
 erklärt werden. Diese steuern die Verteilung der Daten an die einzelnen Plugins.
 
-<center>![](../img/server.png)</center>
+![Server-Prinzip](../img/server.png)

--- a/docu/docs/stylesheets/extra.css
+++ b/docu/docs/stylesheets/extra.css
@@ -1,0 +1,36 @@
+/* Zentriert Bilder mit dem Attribut align="center" */
+img[align="center"] {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Optional: zentriere auch Bilder mit einer CSS-Klasse .center */
+img.center {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Optional: zentrierter Text via .center-text */
+.center-text {
+  text-align: center;
+}
+/* Optional: zentrierter Text via .text-center */
+.text-center {
+  text-align: center;
+}
+
+/* Zentriert Bilder in einem Link <a>-Tag */
+/* Diese Regel gilt für Bilder, die in einem Link-Tag eingebettet sind */ 
+a img[align="center"] {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Optional: zentriert Bilder in einem Link-Tag mit der Klasse .center */
+a.center img {
+  display: block;
+  margin: 0 auto;
+}

--- a/docu/mkdocs.yml
+++ b/docu/mkdocs.yml
@@ -12,7 +12,7 @@ nav:
 #      - BOSWatch benutzen: tbd.md
 #      - Als Service einrichten: tbd.md
   - Informationen:
-       - Server/Cient Prinzip: information/serverclient.md
+       - Server/Client Prinzip: information/serverclient.md
        - Broadcast Service: information/broadcast.md
 #      - Modul/Plugin Konzept: tbd.md
        - Routing Mechanismus: information/router.md

--- a/docu/mkdocs.yml
+++ b/docu/mkdocs.yml
@@ -41,4 +41,8 @@ theme:
   highlightjs: true
   hljs_style: github
 
+extra_css:
+  - stylesheets/extra.css
 
+markdown_extensions:
+  - attr_list


### PR DESCRIPTION
Ergänzung zum Pull #131.

Die Bildlinks sind jetzt korrigiert.
index.md: Logo.png & PayPal-Link
Broadcast.md: Broadcast.png
Router.md: Router.md
Serverclient.md: client.png & server.png
mkdocs.yml: kleiner Typo in Menü "Informationen --> Server/C**L**ient-Prinzip

Hoffe ich hab nix übersehen.

Das Ergebnis kann man hier begutachten: https://koenigmjr.github.io/BW3-Core/

Leider **nachteilig** an dem Ganzen ist, dass die Bilder nun nicht mehr mittig sind.
Allerdings durch `<center>` verschluckt sich Markdown. Fokus war bei der Fehlerbehebung nun vorrangig Markdown beizubehalten und keinen HTML-Code zu verwenden.

Man könnte wohl als Plan B mit CSS arbeiten und die Bilder wieder mittig rücken damit. Allerdings mit ich mit den StyleSheets nicht so vertraut und in meinem Kopf macht das dann den Ansatz "textnah" zu sein wieder kaputt.

Gerne kommentieren falls Änderungen erwünscht oder gleich ändern :)