### PR TITLE
feat(logging): dynamische Logdateibenennung des Client basierend auf YAML-Datei

### DIFF
--- a/bw_client.py
+++ b/bw_client.py
@@ -27,11 +27,14 @@ if not paths.makeDirIfNotExist(paths.LOG_PATH):
     print("cannot find/create log directory: %s", paths.LOG_PATH)
     exit(1)
 
+import logging
 import logging.config
+import logging.handlers
 import argparse
 import os
+import builtins
 
-# Argumente zuerst parsen
+# parsing arguments first - this is needed to load the logging config file with the correct log filename
 parser = argparse.ArgumentParser(prog="bw_client.py",
                                  description="""BOSWatch is a Python Script to receive and
                                  decode german BOS information with rtl_fm and multimon-NG""",
@@ -42,27 +45,12 @@ parser.add_argument("-c", "--config", help="Name to configuration File", require
 parser.add_argument("-t", "--test", help="Start Client with testdata-set", action="store_true")
 args = parser.parse_args()
 
-# Logging-Konfiguration laden
+# set the log filename in the global namespace (mandatory for fileConfig)
+basename = os.path.splitext(args.config)[0]
+log_filename = f"{paths.LOG_PATH}{basename}.log"
+builtins.log_filename = log_filename
+
 logging.config.fileConfig(paths.CONFIG_PATH + "logger_client.ini", disable_existing_loggers=False)
-
-# Dynamischer Logdateiname basierend auf YAML-Datei
-yaml_basename = os.path.splitext(args.config)[0]
-log_filename = f"{paths.LOG_PATH}{yaml_basename}.log"
-
-for handler in logging.getLogger().handlers:
-    if isinstance(handler, logging.handlers.TimedRotatingFileHandler):
-        handler.baseFilename = os.path.abspath(log_filename)
-        handler.stream.close()
-        handler.stream = open(handler.baseFilename, handler.mode)
-
-# Placeholder-Logdatei löschen, falls dynamisch umgebogen
-placeholder_log = os.path.abspath(os.path.join(paths.LOG_PATH, "client.log"))
-if os.path.abspath(log_filename) != placeholder_log and os.path.isfile(placeholder_log):
-    try:
-        os.remove(placeholder_log)
-        logging.debug("Überflüssige client.log gelöscht.")
-    except Exception as e:
-        logging.warning("Fehler beim Löschen von client.log: %s", e)
 
 logging.debug("")
 logging.debug("######################## NEW LOG ############################")

--- a/bw_client.py
+++ b/bw_client.py
@@ -10,7 +10,7 @@ r"""!
                      by Bastian Schroll
 
 @file:        bw_client.py
-@date:        09.12.2017
+@date:        16.07.2025
 @author:      Bastian Schroll
 @description: BOSWatch client application
 """
@@ -28,7 +28,42 @@ if not paths.makeDirIfNotExist(paths.LOG_PATH):
     exit(1)
 
 import logging.config
-logging.config.fileConfig(paths.CONFIG_PATH + "logger_client.ini")
+import argparse
+import os
+
+# Argumente zuerst parsen
+parser = argparse.ArgumentParser(prog="bw_client.py",
+                                 description="""BOSWatch is a Python Script to receive and
+                                 decode german BOS information with rtl_fm and multimon-NG""",
+                                 epilog="""More options you can find in the extern client.ini
+                                 file in the folder /config""")
+# With -h or --help you get the Args help
+parser.add_argument("-c", "--config", help="Name to configuration File", required=True)
+parser.add_argument("-t", "--test", help="Start Client with testdata-set", action="store_true")
+args = parser.parse_args()
+
+# Logging-Konfiguration laden
+logging.config.fileConfig(paths.CONFIG_PATH + "logger_client.ini", disable_existing_loggers=False)
+
+# Dynamischer Logdateiname basierend auf YAML-Datei
+yaml_basename = os.path.splitext(args.config)[0]
+log_filename = f"{paths.LOG_PATH}{yaml_basename}.log"
+
+for handler in logging.getLogger().handlers:
+    if isinstance(handler, logging.handlers.TimedRotatingFileHandler):
+        handler.baseFilename = os.path.abspath(log_filename)
+        handler.stream.close()
+        handler.stream = open(handler.baseFilename, handler.mode)
+
+# Placeholder-Logdatei löschen, falls dynamisch umgebogen
+placeholder_log = os.path.abspath(os.path.join(paths.LOG_PATH, "client.log"))
+if os.path.abspath(log_filename) != placeholder_log and os.path.isfile(placeholder_log):
+    try:
+        os.remove(placeholder_log)
+        logging.debug("Überflüssige client.log gelöscht.")
+    except Exception as e:
+        logging.warning("Fehler beim Löschen von client.log: %s", e)
+
 logging.debug("")
 logging.debug("######################## NEW LOG ############################")
 logging.debug("BOSWatch client has started ...")
@@ -56,15 +91,6 @@ from boswatch.decoder.decoder import Decoder  # for test mode
 header.logoToLog()
 header.infoToLog()
 
-# With -h or --help you get the Args help
-parser = argparse.ArgumentParser(prog="bw_client.py",
-                                 description="""BOSWatch is a Python Script to receive and
-                                 decode german BOS information with rtl_fm and multimon-NG""",
-                                 epilog="""More options you can find in the extern client.ini
-                                 file in the folder /config""")
-parser.add_argument("-c", "--config", help="Name to configuration File", required=True)
-parser.add_argument("-t", "--test", help="Start Client with testdata-set", action="store_true")
-args = parser.parse_args()
 
 bwConfig = ConfigYAML()
 if not bwConfig.loadConfigFile(paths.CONFIG_PATH + args.config):

--- a/config/logger_client.ini
+++ b/config/logger_client.ini
@@ -13,6 +13,7 @@ keys=root
 [logger_root]
 handlers=screen,file
 level=NOTSET
+# NOTSET means: accept all levels (the handlers will filter by their own level)
 
 [formatters]
 keys=simple,complex
@@ -30,11 +31,14 @@ keys=file,screen
 
 [handler_file]
 class=handlers.TimedRotatingFileHandler
-interval=midnight
-backupCount=7
 formatter=complex
 level=ERROR
-args=('log/client.log',)
+args=(log_filename, 'midnight', 1, 7, 'utf-8')
+# explaining args:
+# - 'midnight'  → rotate daily at midnight, Options: 'S', 'M', 'H', 'D', 'midnight' or 'W0'-'W6' (0=Monday, 6=Sunday)
+# - 1           → rotate every 1 "x" (see line above), Options: 1, 2, ..., 31
+# - 7           → keep last 7 logs, Options: 1, 2, ..., 31
+# - 'utf-8'     → encoding of the log file, don't change
 
 [handler_screen]
 class=StreamHandler

--- a/config/logger_server.ini
+++ b/config/logger_server.ini
@@ -13,6 +13,7 @@ keys=root
 [logger_root]
 handlers=screen,file
 level=NOTSET
+# NOTSET means: accept all levels (the handlers will filter by their own level)
 
 [formatters]
 keys=simple,complex
@@ -30,11 +31,14 @@ keys=file,screen
 
 [handler_file]
 class=handlers.TimedRotatingFileHandler
-interval=midnight
-backupCount=7
 formatter=complex
 level=ERROR
-args=('log/server.log',)
+args=('log/server.log', 'midnight', 1, 7, 'utf-8')
+# explaining args:
+# - 'midnight'  → rotate daily at midnight, Options: 'S', 'M', 'H', 'D', 'midnight' or 'W0'-'W6' (0=Monday, 6=Sunday)
+# - 1           → rotate every 1 "x" (see line above), Options: 1, 2, ..., 31
+# - 7           → keep last 7 logs, Options: 1, 2, ..., 31
+# - 'utf-8'     → encoding of the log file, don't change
 
 [handler_screen]
 class=StreamHandler


### PR DESCRIPTION
- Logdatei wird nun zur Laufzeit anhand des Konfigurationsdateinamens gesetzt, z. B.: client1.yaml → log/client1.log
- Ermöglicht parallele Ausführung mehrerer Clients mit getrennten Logs auf derselben Hardware
- Der bisher fest codierte client.log entfällt
- Argumente (args.config) werden nun vor dem Logging-Setup geparst
- logger_client.ini bleibt erhalten; Pfad des TimedRotatingFileHandler wird nachträglich im Code gesetzt
- Log-Rotation (Mitternacht, 7 Backups) funktioniert weiterhin wie konfiguriert
- `disable_existing_loggers=False` verhindert das Deaktivieren benutzerdefinierter Logger in den BOSWatch-Modulen
- Falls die zuvor standardmäßige placeholder-Datei `log/client.log` noch existiert und nicht mehr verwendet wird, wird sie beim Start automatisch gelöscht

BREAKING CHANGE: Logging wird nicht mehr standardmäßig nach log/client.log geschrieben