### PR TITLE
bugfix: Behebung der "[WARNING ] field not found" im Log

### DIFF
--- a/boswatch/wildcard.py
+++ b/boswatch/wildcard.py
@@ -1,25 +1,23 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 r"""!
-    ____  ____  ______       __      __       __       _____
-   / __ )/ __ \/ ___/ |     / /___ _/ /______/ /_     |__  /
+    ____  ____  ______        __      __      __      _____
+   / __ )/ __ \/ ___/ |      / /___ _/ /______/ /_     |__  /
   / __  / / / /\__ \| | /| / / __ `/ __/ ___/ __ \     /_ <
  / /_/ / /_/ /___/ /| |/ |/ / /_/ / /_/ /__/ / / /   ___/ /
 /_____/\____//____/ |__/|__/\__,_/\__/\___/_/ /_/   /____/
-                German BOS Information Script
-                     by Bastian Schroll
+                   German BOS Information Script
+                         by Bastian Schroll
 
-@file:        wildcard.py
-@date:        15.01.2018
-@author:      Bastian Schroll
+@file:       wildcard.py
+@date:       23.07.2025
+@author:     Bastian Schroll
 @description: Functions to replace wildcards in stings
 """
 import logging
 import time
 
 logging.debug("- %s loaded", __name__)
-
-# todo check function - write an test
 
 _additionalWildcards = {}
 
@@ -42,6 +40,8 @@ def replaceWildcards(message, bwPacket):
     @param message: Message in which wildcards should be replaced
     @param bwPacket: bwPacket instance with the replacement information
     @return Input message with the replaced wildcards"""
+
+    # Start with wildcards that are always available
     _wildcards = {
         # formatting wildcards
         # todo check if br and par are needed - if not also change config
@@ -69,34 +69,58 @@ def replaceWildcards(message, bwPacket):
         "{TIMES}": bwPacket.get("timestamp"),
         "{FREQ}": bwPacket.get("frequency"),
         "{MODE}": bwPacket.get("mode"),
-
-        # fms wildcards
-        "{FMS}": bwPacket.get("fms"),
-        "{SERV}": bwPacket.get("service"),
-        "{COUNT}": bwPacket.get("country"),
-        "{LOC}": bwPacket.get("location"),
-        "{VEHC}": bwPacket.get("vehicle"),
-        "{STAT}": bwPacket.get("status"),
-        "{DIR}": bwPacket.get("direction"),
-        "{DIRT}": bwPacket.get("directionText"),
-        "{TACI}": bwPacket.get("tacticalInfo"),
-
-        # pocsag wildcards
-        "{BIT}": bwPacket.get("bitrate"),
-        "{RIC}": bwPacket.get("ric"),
-        "{SRIC}": bwPacket.get("subric"),
-        "{SRICT}": bwPacket.get("subricText"),
-        "{MSG}": bwPacket.get("message"),
-
-        # zvei wildcards
-        "{TONE}": bwPacket.get("tone"),
-
-        # message for MSG packet is done in poc
     }
+
+    # Get the packet mode to add specific wildcards
+    mode = bwPacket.get("mode")
+
+    # fms wildcards
+    if mode == "fms":
+        fms_wildcards = {
+            "{FMS}": bwPacket.get("fms"),
+            "{SERV}": bwPacket.get("service"),
+            "{COUNT}": bwPacket.get("country"),
+            "{LOC}": bwPacket.get("location"),
+            "{VEHC}": bwPacket.get("vehicle"),
+            "{STAT}": bwPacket.get("status"),
+            "{DIR}": bwPacket.get("direction"),
+            "{DIRT}": bwPacket.get("directionText"),
+            "{TACI}": bwPacket.get("tacticalInfo"),
+        }
+        _wildcards.update(fms_wildcards)
+
+    # pocsag wildcards
+    elif mode == "pocsag":
+        pocsag_wildcards = {
+            "{BIT}": bwPacket.get("bitrate"),
+            "{RIC}": bwPacket.get("ric"),
+            "{SRIC}": bwPacket.get("subric"),
+            "{SRICT}": bwPacket.get("subricText"),
+            "{MSG}": bwPacket.get("message"),
+        }
+        _wildcards.update(pocsag_wildcards)
+
+    # zvei wildcards
+    elif mode == "zvei":
+        zvei_wildcards = {
+            "{TONE}": bwPacket.get("tone"),
+        }
+        _wildcards.update(zvei_wildcards)
+
+    # msg wildcards
+    elif mode == "msg":
+        msg_wildcards = {
+            "{MSG}": bwPacket.get("message"),
+        }
+        _wildcards.update(msg_wildcards)
+
+    # Now, replace all collected wildcards
     for wildcard, field in _wildcards.items():
+        # Only replace if the field was found in the packet (is not None)
         if field is not None:
             message = message.replace(wildcard, field)
 
+    # Handle additional, dynamically registered wildcards
     for wildcard, fieldName in _additionalWildcards.items():
         field = bwPacket.get(fieldName)
         if field is not None:


### PR DESCRIPTION
Bedingt durch die modeunabhängige Verarbeitung sämtlicher Wildcards warnt das Programm, dass manche Felder nicht verfügbar sind, die in der derzeitigen Auswertung jedoch gar nicht vorhanden sein können (z.B. FMS Felder in ZVEI-Datensatz etc.).
Auf Loglevel "WARNING" oder darunter kommt es dann zu Fehlern wie: **[WARNING ] field not found: fms** bei allen Datensätzen, die eben nicht FMS entsprechen (und beinhalten).

Änderungen:
- Wildcard-Ersetzung in `replaceWildcards()` nach Paketmodus (fms, pocsag, zvei, msg) aufgeteilt
- Unnötige Wildcards werden nun abhängig vom Modus nicht mehr verarbeitet
- `{MSG}` wird nun explizit für den Modus `msg` unterstützt
- Kopfzeile mit aktuellem Änderungsdatum versehen

Sry für die vielen Pull Requests. Allerdings wenn ich schon Änderungen im Code mache, die mir für die breite Masse sinnig erscheinen, dann stelle ich sie eben auf diesem Wege der Allgemeinheit zur Verfügung.
Und ich denke themenbezogene PRs sind besser wie ein Großer mit Allen; macht in meinen Augen die Veränderungen leichter zum reviewen.

Schönes Wochenende!