### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -1,4 +1,6 @@
 name: pytest
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BOSWatch/BW3-Core/security/code-scanning/2](https://github.com/BOSWatch/BW3-Core/security/code-scanning/2)

To fix the problem, you should add a `permissions` block that restricts the permissions of the GitHub Actions workflow to the least privilege necessary. Since this workflow only installs dependencies, runs pytest, and uploads an artifact, it most likely only needs `contents: read` permissions to check out the repository content.

- In general, you add a `permissions` key at the root of the workflow YAML file (applies to all jobs) or inside each job definition if you want to scope more tightly.
- For this fix, add the block at the top (after `name:` and before `on:`) so that all jobs inherit `contents: read`.
- No changes to any code outside the YAML are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
