### PR TITLE
(bugfix/mysql): Change: Remove whitespace and check for empty strings

### DIFF
--- a/plugin/mysql.py
+++ b/plugin/mysql.py
@@ -57,8 +57,11 @@ class BoswatchPlugin(PluginBase):
         if self.cursor.fetchone() is None:
             with open('init_db.sql') as f:
                 for stmnt in f.read().split(';'):
-                    self.cursor.execute(stmnt)
-                    self.connection.commit()
+                    # Change: Remove whitespace and check for empty strings
+                    clean_stmnt = stmnt.strip()
+                    if clean_stmnt:  # only if the string is not empty
+                        self.cursor.execute(clean_stmnt)
+                        self.connection.commit()
 
         self.cursor.close()
 


### PR DESCRIPTION
Servus zusammen,

MySQL-Fehler wegen leerem Statement am Schluss von der DB_init Datei weil `f.read().split(';')` ja korrekterweise nach jedem ";" teilt. Jetzt schließt halt die init_db.sql-Datei mit...

```
[...]
	frequency varchar(30) not null
);
create unique index boswatch_id_uindex
	on boswatch (id);
```

ab

und `f.read().split(';')` macht zum Schluss (nach boswatch(id)) nochmal einen leeren String.

Mit der eingefügten Prüfung auf leere Strings wird das vermieden.

Im Anschluss nochmal der Error:
```
??? python[22805]: Traceback (most recent call last):
??? python[22805]:    File "/opt/boswatch3/venv/lib/python3.13/site-packages/mysql/connector/connection_cext.py", line 772, in cmd_query
??? python[22805]:       self._cmysql.query(
??? python[22805]:       ~~~~~~~~~~~~~~~~~~^
??? python[22805]:             query,
??? python[22805]:             ^^^^^^
??? python[22805]:       ...<3 lines>...
??? python[22805]:             query_attrs=self.query_attrs,
??? python[22805]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
??? python[22805]:       )
??? python[22805]:       ^
??? python[22805]: _mysql_connector.MySQLInterfaceError: Query was empty
??? python[22805]: The above exception was the direct cause of the following exception:
??? python[22805]: Traceback (most recent call last):
??? python[22805]:    File "/opt/boswatch3/bw_server.py", line 79, in <module>
??? python[22805]:       if not bwRoutMan.buildRouters(bwConfig):
??? python[22805]:              ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
??? python[22805]:    File "/opt/boswatch3/boswatch/router/routerManager.py", line 77, in buildRouters
??? python[22805]:       loadedClass = importedFile.BoswatchPlugin(routeConfig)
??? python[22805]:    File "/opt/boswatch3/plugin/mysql.py", line 35, in __init__
??? python[22805]:       super().__init__(__name__, config)  # you can access the config class on 'self.config'
??? python[22805]:       ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
??? python[22805]:    File "/opt/boswatch3/plugin/pluginBase.py", line 54, in __init__
??? python[22805]:       self.onLoad()
??? python[22805]:       ~~~~~~~~~~~^^
??? python[22805]:    File "/opt/boswatch3/plugin/mysql.py", line 60, in onLoad
??? python[22805]:       self.cursor.execute(stmnt)
??? python[22805]:       ~~~~~~~~~~~~~~~~~~~^^^^^^^
??? python[22805]:    File "/opt/boswatch3/venv/lib/python3.13/site-packages/mysql/connector/cursor_cext.py", line 353, in execute
??? python[22805]:       self._connection.cmd_query(
??? python[22805]:       ~~~~~~~~~~~~~~~~~~~~~~~~~~^
??? python[22805]:             self._stmt_partition["mappable_stmt"],
??? python[22805]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
??? python[22805]:       ...<2 lines>...
??? python[22805]:             raw_as_string=self._raw_as_string,
??? python[22805]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
??? python[22805]:       )
??? python[22805]:       ^
??? python[22805]:    File "/opt/boswatch3/venv/lib/python3.13/site-packages/mysql/connector/opentelemetry/context_propagation.py", line 97, in wrapper
??? python[22805]:       return method(cnx, *args, **kwargs)
??? python[22805]:    File "/opt/boswatch3/venv/lib/python3.13/site-packages/mysql/connector/connection_cext.py", line 781, in cmd_query
??? python[22805]:       raise get_mysql_exception(
??? python[22805]:             err.errno, msg=err.msg, sqlstate=err.sqlstate
??? python[22805]:       ) from err
??? python[22805]: mysql.connector.errors.ProgrammingError: 1065 (42000): Query was empty
```