### PR TITLE
docs(packet): Ergänzung um {TIME}, {BR}, {LPAR}, {RPAR}

### DIFF
--- a/docu/docs/develop/packet.md
+++ b/docu/docs/develop/packet.md
@@ -21,6 +21,20 @@ Ein BOSWatch Datenpaket wird in einem Python Dict abgebildet. In der nachfolgend
 |mode|X|X|X|X|`{MODE}`|(fms, pocsag, zvei, msg)|
 
 ---
+### Allgemeine (feldunabhängige) Wildcards
+
+Diese Wildcards sind **nicht an ein bestimmtes Feld im BOSWatch Paket gebunden**.  
+Sie können **in allen Texten** verwendet werden, die Wildcards unterstützen
+(z. B. Descriptor, Templates, Benachrichtigungen).
+
+|Wildcard|Beschreibung|
+|--------|------------|
+|`{BR}`|Zeilenumbruch (`\r\n`)|
+|`{LPAR}`|Öffnende Klammer `(`|
+|`{RPAR}`|Schließende Klammer `)`|
+|`{TIME}`|Aktueller Zeitstempel im Format `%d.%m.%Y %H:%M:%S`|
+
+---
 ## Speziell für POCSAG
 |Feldname|FMS|POCSAG|ZVEI|MSG|Wildcard|Beschreibung|
 |--------|:-:|:----:|:--:|:-:|--------|------------|


### PR DESCRIPTION
Servus,

nur eine kleine Änderung in der Readme, aber ich bin selbst bisschen drüber gestolpert, dass es die Wildcards gibt, da ich immer auf die "Alarmpaket-Format"-Seite geschaut habe und übersehen habe, dass es {TIME} gibt.

Es steht zwar sehr schön bei "Eigenes Modul/Plugin schreiben", allerdings sind die Wildcards auch für User interessant, die nicht vorhaben, ein neues Modul/Plugin zu schreiben.

Zumindest das {TIME}-Wildcard. Allerdings vollständigkeitshalber mal alle.

Eure Meinung bitte, danke und schöne Grüße :)