### PR TITLE
[bugfix/testroutine] Pytest-Absturz in der Testroutine behoben (Flake8 entkoppelt)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,33 +6,10 @@
 #                German BOS Information Script
 #                     by Bastian Schroll
 
-# virtual environment
-venv/
-.venv/
-
-# generated files
-stats_*
-log/
-docu/docs/api/html
-docu/site/
-
-# Logo Photoshop file
-*.psd
-
-# Coverage Report
-.coverage
-
-# Python precompiled
-*.pyc
-
-# Visual Studio Code
-.pytest_cache/
-
-# PyCharm IDE
-.cache/
-.idea/
-
-# Eclipse IDE (PyDev)
-.settings/
-.project
-.pydevproject
+[flake8]
+extend-ignore = E402, E501, E722, W504, W605
+exclude =
+    .git,
+    __pycache__,
+    .venv,
+    venv

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -30,15 +30,11 @@ jobs:
 
     - name: Run Flake8
       run: |
-        flake8 . --extend-ignore=E402,E501,E722,W504,W605
-        # E402 # import not at top
-        # E501 # line too long
-        # E722 # do not use bare 'except'
-        # W504 # line break after binary operator
-        # W605 # invalid escape sequence
-        # flake8-max-line-length = 99
+        flake8 .
 
     - name: Test with pytest
+      env:
+        RUN_NETWORK_TESTS: "true"
       run: |
         pytest -c 'test/pytest.ini'
 

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -16,10 +15,10 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{matrix.python-version}} at ${{matrix.os}}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -28,6 +27,16 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         mkdir -p log/
+
+    - name: Run Flake8
+      run: |
+        flake8 . --extend-ignore=E402,E501,E722,W504,W605
+        # E402 # import not at top
+        # E501 # line too long
+        # E722 # do not use bare 'except'
+        # W504 # line break after binary operator
+        # W605 # invalid escape sequence
+        # flake8-max-line-length = 99
 
     - name: Test with pytest
       run: |

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,27 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run Full Check (Lint & Test)",
+      "type": "shell",
+      "command": "make check",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run Flake8 (Linter)",
+      "type": "shell",
+      "command": "make lint",
+      "problemMatcher": []
+    },
+    {
+      "label": "Run Pytest (Tests)",
+      "type": "shell",
+      "command": "make test",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+# standard is 'python3', but you can replace with:
+# make install PYTHON=python3.14
+PYTHON ?= python3
+VENV = .venv
+PIP = $(VENV)/bin/pip
+
+.DEFAULT_GOAL := help
+
+help:
+	@echo "Available commands:"
+	@echo "  make install     - Create virtual environment and install dependencies"
+	@echo "  make lint        - Run Flake8 linter"
+	@echo "  make test        - Run Pytest suite"
+	@echo "  make check       - Run linter AND tests (Fail-Fast)"
+	@echo "  make clean       - Remove virtual environment"
+
+# Install
+install:
+	$(PYTHON) -m venv $(VENV)
+	$(PIP) install --upgrade pip
+	$(PIP) install -r requirements.txt
+	@echo "Installation abgeschlossen."
+	@echo "Aktiviere das venv mit: 'source $(VENV)/bin/activate' (oder fish: 'source .venv/bin/activate.fish')"
+
+check: lint test
+
+lint:
+	$(VENV)/bin/flake8 .
+
+test:
+	$(VENV)/bin/pytest -c test/pytest.ini
+
+clean:
+	rm -rf $(VENV)
+
+.PHONY: install test lint check clean

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,4 @@ mkdocs
 pytest
 pytest-cov
 flake8==6.1.0
-pytest-flake8
-pytest-flakes
 pytest-randomly

--- a/test/boswatch/test_broadcast.py
+++ b/test/boswatch/test_broadcast.py
@@ -16,6 +16,7 @@ r"""!
 """
 # problem of the pytest fixtures
 # pylint: disable=redefined-outer-name
+import os
 import logging
 import pytest
 
@@ -68,6 +69,7 @@ def test_clientWithoutServer(broadcastClient):
     assert not broadcastClient.getConnInfo(1)
 
 
+@pytest.mark.skipif(os.environ.get("RUN_NETWORK_TESTS") != "true", reason="Skip in local environment")
 def test_serverClientFetchConnInfo(broadcastClient, broadcastServer):
     r"""!Fetch connection info from BroadcastServer"""
     assert broadcastServer.start()

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -8,7 +8,7 @@
 #                     by Bastian Schroll
 
 [pytest]
-addopts = -v --flake8 --flakes --cov=boswatch/ --cov=module/ --cov plugin/ --cov-report=term-missing --log-level=CRITICAL
+addopts = -v --cov=boswatch/ --cov=module/ --cov plugin/ --cov-report=term-missing --log-level=CRITICAL
 
 # classic or progress
 console_output_style = progress 
@@ -17,12 +17,3 @@ log_file=log/test.log
 log_file_level=debug
 log_file_format=%(asctime)s - %(module)-12s %(funcName)-15s [%(levelname)-8s] %(message)s
 log_file_date_format=%d.%m.%Y %H:%M:%S
-
-#flake8 plugin
-flake8-ignore = E402 E501 E722 W504 W605
-# E402 # import not at top
-# E501 # line too long
-# E722 # do not use bare 'except'
-# W504 # line break after binary operator
-# W605 # invalid escape sequence
-# flake8-max-line-length = 99


### PR DESCRIPTION
### Problem
Die CI-Pipeline ist aufgrund einer Inkompatibilität zwischen neueren `pytest`-Versionen (v8+) und den veralteten Plugins `pytest-flake8` / `pytest-flakes` fehlgeschlagen. Da diese Plugins nicht mehr aktiv gepflegt werden, kam es beim Starten der Tests zu folgendem Validierungsfehler:

```text
pluggy._manager.PluginValidationError: Plugin 'flake8' for hook 'pytest_collect_file'
hookimpl definition: pytest_collect_file(file_path, path, parent)
Argument(s) {'path'} are declared in the hookimpl but can not be found in the hookspec
Error: Process completed with exit code 1.