### PR TITLE
[bugfix/descriptor] Änderung im Verhalten von leeren Strings

### DIFF
--- a/module/descriptor.py
+++ b/module/descriptor.py
@@ -10,7 +10,7 @@ r"""!
                      by Bastian Schroll
 
 @file:        descriptor.py
-@date:        03.12.2025
+@date:        01.07.2026
 @author:      Bastian Schroll
 @description: Module to add descriptions to bwPackets with CSV and Regex support
 """
@@ -207,7 +207,7 @@ class BoswatchModule(ModuleBase):
             # Search for matching description in unified cache
             description = self._find_description(descriptor_key, scan_value, bwPacket)
 
-            if description:
+            if description is not None:
                 bwPacket.set(descr_field, description)
                 logging.info("Description set: '%s' -> '%s'", scan_value, description)
             else:


### PR DESCRIPTION
## Beschreibung
Dieser PR behebt einen Fehler im `descriptor`-Modul, bei dem explizit definierte, leere Ersetzungstexte (`add: ""`) ignoriert wurden.

### Das Problem
Wenn man in einer CSV- oder YAML-Konfiguration ein Wildcard- oder Catch-All-Regex-Muster verwendet (zum Beispiel `.*,,true`, um ein Feld zu leeren oder zurückzusetzen, falls keine andere Regel greift), fiel das Modul fälschlicherweise auf den ursprünglichen `scan_value` zurück. Dies geschah, weil die "Truthy"-Prüfung `if description:` einen leeren String (`""`) genauso behandelte wie `None` (kein Treffer gefunden).

### Die Lösung
Die bedingte Prüfung in `doWork()` wurde von `if description:` auf `if description is not None:` umgestellt. Dadurch wird die Logik für „kein Treffer gefunden“ sauber von „Treffer gefunden, aber der Zielwert ist leer“ getrennt. Das ermöglicht es nun, Felder absichtlich zu leeren oder mit einem leeren Text zu überschreiben.

## Technische Änderungen
* **module/descriptor.py**: `if description:` in der Hauptschleife von `doWork` zu `if description is not None:` geändert.

## Verifizierung / Testergebnisse
* Es wurde überprüft, dass CSV-Einträge mit leeren Feldern (`.*,,true`) das Zielfeld nun erfolgreich mit einem leeren String überschreiben.
* Es wurde überprüft, dass bestehende, gültige Textbeschreibungen (`add-value`) weiterhin korrekt zugewiesen werden, ohne die Abwärtskompatibilität zu beeinträchtigen.
* Es wurde sichergestellt, dass keine Exceptions geworfen werden, wenn `_find_description` den Wert `None` zurückgibt.