### PR TITLE
fix(server): validate packet length header before parsing

### DIFF
--- a/boswatch/network/server.py
+++ b/boswatch/network/server.py
@@ -50,7 +50,12 @@ class _ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
                 if not len(header):
                     break  # empty data -> socked closed
 
-                length = int(header.strip())
+                try:
+                    length = int(header.strip())
+                except ValueError:
+                    logging.error("%s sent an invalid packet header (expected an integer length, got %r) - closing connection", req_name, header)
+                    break
+
                 data = self.request.recv(length).decode("utf-8")
 
                 if data == "<keep-alive>":

--- a/test/boswatch/test_ServerClient.py
+++ b/test/boswatch/test_ServerClient.py
@@ -17,6 +17,7 @@ r"""!
 # problem of the pytest fixtures
 # pylint: disable=redefined-outer-name
 import logging
+import socket
 import time
 import queue
 import pytest
@@ -117,6 +118,30 @@ def test_clientCommunicate(getClient, getRunningServer):
     assert getClient.transmit("test")
     assert getClient.receive() == "[ack]"
     assert getClient.disconnect()
+
+
+def test_serverInvalidHeaderClosesConnectionOnly(getRunningServer, caplog):
+    r"""!Send a non-integer length header - server must log a clear error and
+    drop just that connection, without crashing or affecting other clients"""
+    rawSock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    rawSock.settimeout(3)
+    rawSock.connect(("localhost", 8080))
+    with caplog.at_level(logging.ERROR):
+        rawSock.sendall(b"bad_head!!")  # 10 bytes (HEADERSIZE), not a valid int
+        time.sleep(0.2)  # let the server thread process and close
+
+    assert any("invalid packet header" in record.message for record in caplog.records)
+
+    # the malformed connection must be closed, not left hanging
+    assert rawSock.recv(1) == b""
+    rawSock.close()
+
+    # the server itself (and other clients) must be unaffected
+    normalClient = TCPClient()
+    assert normalClient.connect()
+    assert normalClient.transmit("test")
+    assert normalClient.receive() == "[ack]"
+    assert normalClient.disconnect()
 
 
 @pytest.mark.skip("needs fixture for more than one client")


### PR DESCRIPTION
Closes #155.

## Root cause

`_ThreadedTCPRequestHandler.handle()` parses the 10-byte length header with a bare `int(header.strip())`. If the TCP stream ever gets desynced (as reported, apparently from connection instability over VPN/multi-network client setups), the bytes read as "header" aren't a valid integer, and the unhandled `ValueError` kills that client's handler thread with an unstructured traceback — matching the exact error in the issue (`invalid literal for int() with base 10: 'alive>12'`).

## Fix

Wrapped the header parse in `try/except ValueError`, logging a clear error identifying the client and the malformed header content, then closing just that connection cleanly — instead of an unhandled exception.

## Testing

Added `test_serverInvalidHeaderClosesConnectionOnly`: opens a raw socket, sends a 10-byte non-integer header (`b"bad_head!!"`), and asserts the server (1) logs a clear error, (2) closes that connection, (3) keeps working normally for other clients afterward.

Verified non-vacuously: reverting just the fix reproduces the exact reported traceback and the test fails; restoring it, the test passes. Full suite: 65 passed / 4 skipped (one unrelated broadcast-socket test is flaky in this sandboxed environment specifically — confirmed pre-existing by re-running in isolation and re-running the full suite clean, unrelated to this change). `flake8` clean on both changed files.

## Note on a related, separate finding

While investigating, the linked comment thread surfaced a `SyntaxError` crash in `packet.py`, which parses incoming packet data via `eval(str(bwPacket.strip()))` — i.e. `eval()` on raw network input. That's a distinct, more serious concern (arbitrary code execution risk from untrusted socket data) than the header-validation bug here, so I've deliberately left it out of this PR. Happy to open a separate issue/PR for it if useful.